### PR TITLE
Fixed make_dense Scipy .A deprecation

### DIFF
--- a/src/mousipy/mousipy.py
+++ b/src/mousipy/mousipy.py
@@ -20,7 +20,7 @@ m2h_tab_hcop = pd.read_csv(os.path.join(path, './hcop/mouse_to_human.csv')).set_
 def make_dense(X):
     # robustly make an array dense
     if issparse(X):
-        return X.A
+        return X.toarray()
     else:
         return X
 


### PR DESCRIPTION
Closes #7 

Scipy deprecated the .A attribute in 1.14
https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#deprecated-features